### PR TITLE
Original code from bitcoin and bitcoin_hashes crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ script:
     else
       cargo build --verbose
       cargo test --verbose
+      cargo test --verbose --features "serde"
       cargo build --verbose --features "fuzztarget"
       cargo build --verbose --no-default-features
     fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bitcoin_num"
 version = "0.1.0"
-authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
+authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 license = "CC0-1.0"
 description = "Numeric functions & traits used by rust bitcoin, bitcoin_hashes and other packages, supporting rustc 1.29.0"
 documentation = "https://docs.rs/bitcoin_num/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,19 @@ path = "src/lib.rs"
 [features]
 default = [ "std" ]
 std = []
+serde-std = ["serde/std"]
 unstable = []  # for benchmarking
 fuzztarget = [] # used by other rust-bitcoin projects to make hashes almost-noops, DON'T USE THIS
 
+[dev-dependencies]
+serde_test = "1.0"
+
 [dependencies]
+
+[dependencies.serde]
+version = "1.0"
+optional = true
+default-features = false
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,17 +8,19 @@ publish = false
 cargo-fuzz = true
 
 [features]
+afl_fuzz = ["afl"]
 honggfuzz_fuzz = ["honggfuzz"]
 
 [dependencies]
 honggfuzz = { version = "0.5", optional = true }
 bitcoin_num = { path = ".." }
 rust-crypto = "0.2"
+afl = { version = "0.4", optional = true }
 
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
 
-#[[bin]]
-#name = "sha1"
-#path = "fuzz_targets/sha1.rs"
+[[bin]]
+name = "uint128_fuzz"
+path = "fuzz_targets/uint128_fuzz.rs"

--- a/fuzz/fuzz_targets/uint128_fuzz.rs
+++ b/fuzz/fuzz_targets/uint128_fuzz.rs
@@ -1,0 +1,133 @@
+extern crate bitcoin_num;
+
+use std::convert::Into;
+use std::str::FromStr;
+
+fn do_test(data: &[u8]) {
+    macro_rules! read_ints {
+        ($start: expr) => {{
+            let mut native = 0;
+            for c in data[$start..$start + 16].iter() {
+                native <<= 8;
+                native |= (*c) as u128;
+            }
+            // Note BE:
+            let uint128 = bitcoin_num::uint::Uint128::from(
+                &[native as u64, (native >> 8 * 8) as u64][..],
+            );
+
+            // Checking two conversion methods against each other
+            let mut slice = [0u8; 16];
+            slice.copy_from_slice(&data[$start..$start + 16]);
+            assert_eq!(
+                uint128,
+                bitcoin_num::uint::Uint128::from_be_bytes(slice)
+            );
+
+            (native, uint128)
+        }};
+    }
+    macro_rules! check_eq {
+        ($native: expr, $uint: expr) => {{
+            assert_eq!(
+                &[$native as u64, ($native >> 8 * 8) as u64],
+                $uint.as_bytes()
+            );
+        }};
+    }
+
+    if data.len() != 16 * 2 + 1 {
+        return;
+    }
+    let (a_native, a) = read_ints!(0);
+
+    // Checks using only a:
+    for i in 0..128 {
+        check_eq!(a_native << i, a << i);
+        check_eq!(a_native >> i, a >> i);
+    }
+    assert_eq!(a_native as u64, a.low_u64());
+    assert_eq!(a_native as u32, a.low_u32());
+    assert_eq!(128 - a_native.leading_zeros() as usize, a.bits());
+    assert_eq!(
+        a_native as u64,
+        bitcoin_num::uint::Uint128::from_u64(a_native as u64)
+            .unwrap()
+            .low_u64()
+    );
+
+    // Checks with two numbers:
+    let (b_native, b) = read_ints!(16);
+
+    check_eq!(a_native.wrapping_add(b_native), a + b);
+    check_eq!(a_native.wrapping_sub(b_native), a - b);
+    if b_native != 0 {
+        check_eq!(a_native.wrapping_div(b_native), a / b);
+        check_eq!(a_native.wrapping_rem(b_native), a % b);
+    }
+    check_eq!(a_native.wrapping_mul(b_native), a * b);
+    check_eq!(a_native & b_native, a & b);
+    check_eq!(a_native | b_native, a | b);
+    check_eq!(a_native ^ b_native, a ^ b);
+    check_eq!(
+        a_native.wrapping_mul((b_native as u32) as u128),
+        a.mul_u32(b.low_u32())
+    );
+
+    assert_eq!(a_native > b_native, a > b);
+    assert_eq!(a_native >= b_native, a >= b);
+    assert_eq!(a_native < b_native, a < b);
+    assert_eq!(a_native <= b_native, a <= b);
+}
+
+#[cfg(feature = "afl")]
+#[macro_use]
+extern crate afl;
+#[cfg(feature = "afl")]
+fn main() {
+    fuzz!(|data| {
+        do_test(&data);
+    });
+}
+
+#[cfg(feature = "honggfuzz")]
+#[macro_use]
+extern crate honggfuzz;
+#[cfg(feature = "honggfuzz")]
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'...b'F' => b |= c - b'A' + 10,
+                b'a'...b'f' => b |= c - b'a' + 10,
+                b'0'...b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        let mut a = Vec::new();
+        extend_vec_from_hex(
+            "100000a70000000000000000000000000000000000000000000000000000000054",
+            &mut a,
+        );
+        super::do_test(&a);
+    }
+}

--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
 set -e
+
+# Check that input files are correct Windows file names
+incorrectFilenames=$(find . -type f -name "*,*" -o -name "*:*" -o -name "*<*" -o -name "*>*" -o -name "*|*" -o -name "*\?*" -o -name "*\**" -o -name "*\"*" | wc -l)
+
+if [ ${incorrectFilenames} -gt 0 ]; then
+	exit 2
+fi
+
+# Testing
 cargo install --force honggfuzz
 for TARGET in fuzz_targets/*; do
-    FILENAME=$(basename $TARGET)
+	FILENAME=$(basename $TARGET)
 	FILE="${FILENAME%.*}"
 	if [ -d hfuzz_input/$FILE ]; then
 	    HFUZZ_INPUT_ARGS="-f hfuzz_input/$FILE/input"
 	fi
-
-        rm -f hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT
-
-	HFUZZ_BUILD_ARGS="--features honggfuzz_fuzz" HFUZZ_RUN_ARGS="-N1000000 --exit_upon_crash -v $HFUZZ_INPUT_ARGS" cargo hfuzz run $FILE
+	HFUZZ_BUILD_ARGS="--features honggfuzz_fuzz" HFUZZ_RUN_ARGS="--run_time 30 --exit_upon_crash -v $HFUZZ_INPUT_ARGS" cargo hfuzz run $FILE
 
 	if [ -f hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT ]; then
 		cat hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -1,0 +1,144 @@
+// Bitcoin Numeric Library
+// Written in 2018 by
+//   Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Functions for endianess conversions; required to support old Rust
+//! compiler versions
+
+macro_rules! define_slice_to_be {
+    ($name: ident, $type: ty) => {
+        #[inline]
+        pub fn $name(slice: &[u8]) -> $type {
+            assert_eq!(slice.len(), ::core::mem::size_of::<$type>());
+            let mut res = 0;
+            for i in 0..::core::mem::size_of::<$type>() {
+                res |= (slice[i] as $type) << (::core::mem::size_of::<$type>() - i - 1)*8;
+            }
+            res
+        }
+    }
+}
+macro_rules! define_slice_to_le {
+    ($name: ident, $type: ty) => {
+        #[inline]
+        pub fn $name(slice: &[u8]) -> $type {
+            assert_eq!(slice.len(), ::core::mem::size_of::<$type>());
+            let mut res = 0;
+            for i in 0..::core::mem::size_of::<$type>() {
+                res |= (slice[i] as $type) << i*8;
+            }
+            res
+        }
+    }
+}
+macro_rules! define_be_to_array {
+    ($name: ident, $type: ty, $byte_len: expr) => {
+        #[inline]
+        pub fn $name(val: $type) -> [u8; $byte_len] {
+            assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            let mut res = [0; $byte_len];
+            for i in 0..$byte_len {
+                res[i] = ((val >> ($byte_len - i - 1)*8) & 0xff) as u8;
+            }
+            res
+        }
+    }
+}
+macro_rules! define_le_to_array {
+    ($name: ident, $type: ty, $byte_len: expr) => {
+        #[inline]
+        pub fn $name(val: $type) -> [u8; $byte_len] {
+            assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            let mut res = [0; $byte_len];
+            for i in 0..$byte_len {
+                res[i] = ((val >> i*8) & 0xff) as u8;
+            }
+            res
+        }
+    }
+}
+
+define_slice_to_be!(slice_to_u32_be, u32);
+define_slice_to_be!(slice_to_u64_be, u64);
+define_be_to_array!(u32_to_array_be, u32, 4);
+define_slice_to_le!(slice_to_u16_le, u16);
+define_slice_to_le!(slice_to_u32_le, u32);
+define_slice_to_le!(slice_to_u64_le, u64);
+define_le_to_array!(u16_to_array_le, u16, 2);
+define_le_to_array!(u32_to_array_le, u32, 4);
+define_le_to_array!(u64_to_array_le, u64, 8);
+
+#[inline]
+pub fn i16_to_array_le(val: i16) -> [u8; 2] {
+    u16_to_array_le(val as u16)
+}
+#[inline]
+pub fn slice_to_i16_le(slice: &[u8]) -> i16 {
+    slice_to_u16_le(slice) as i16
+}
+#[inline]
+pub fn slice_to_i32_le(slice: &[u8]) -> i32 {
+    slice_to_u32_le(slice) as i32
+}
+#[inline]
+pub fn i32_to_array_le(val: i32) -> [u8; 4] {
+    u32_to_array_le(val as u32)
+}
+#[inline]
+pub fn slice_to_i64_le(slice: &[u8]) -> i64 {
+    slice_to_u64_le(slice) as i64
+}
+#[inline]
+pub fn i64_to_array_le(val: i64) -> [u8; 8] {
+    u64_to_array_le(val as u64)
+}
+
+macro_rules! define_chunk_slice_to_int {
+    ($name: ident, $type: ty, $converter: ident) => {
+        #[inline]
+        pub fn $name(inp: &[u8], outp: &mut [$type]) {
+            assert_eq!(inp.len(), outp.len() * ::core::mem::size_of::<$type>());
+            for (outp_val, data_bytes) in outp.iter_mut().zip(inp.chunks(::core::mem::size_of::<$type>())) {
+                *outp_val = $converter(data_bytes);
+            }
+        }
+    }
+}
+define_chunk_slice_to_int!(bytes_to_u64_slice_le, u64, slice_to_u64_le);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endianness_test() {
+        assert_eq!(slice_to_u32_be(&[0xde, 0xad, 0xbe, 0xef]), 0xdeadbeef);
+        assert_eq!(slice_to_u64_be(&[0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad, 0xca, 0xfe]), 0xdeadbeef1badcafe);
+        assert_eq!(u32_to_array_be(0xdeadbeef), [0xde, 0xad, 0xbe, 0xef]);
+
+        assert_eq!(slice_to_u16_le(&[0xad, 0xde]), 0xdead);
+        assert_eq!(slice_to_u32_le(&[0xef, 0xbe, 0xad, 0xde]), 0xdeadbeef);
+        assert_eq!(slice_to_u64_le(&[0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b]), 0x1badcafedeadbeef);
+        assert_eq!(u16_to_array_le(0xdead), [0xad, 0xde]);
+        assert_eq!(u32_to_array_le(0xdeadbeef), [0xef, 0xbe, 0xad, 0xde]);
+        assert_eq!(u64_to_array_le(0x1badcafedeadbeef), [0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b]);
+    }
+
+    #[test]
+    fn endian_chunk_test() {
+        let inp = [0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b, 0xfe, 0xca, 0xad, 0x1b, 0xce, 0xfa, 0x01, 0x02];
+        let mut out = [0; 2];
+        bytes_to_u64_slice_le(&inp, &mut out);
+        assert_eq!(out, [0x1badcafedeadbeef, 0x0201face1badcafe]);
+    }
+}

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -71,6 +71,7 @@ macro_rules! define_le_to_array {
 define_slice_to_be!(slice_to_u32_be, u32);
 define_slice_to_be!(slice_to_u64_be, u64);
 define_be_to_array!(u32_to_array_be, u32, 4);
+define_be_to_array!(u64_to_array_be, u64, 8);
 define_slice_to_le!(slice_to_u16_le, u16);
 define_slice_to_le!(slice_to_u32_le, u32);
 define_slice_to_le!(slice_to_u64_le, u64);
@@ -125,6 +126,7 @@ mod tests {
         assert_eq!(slice_to_u32_be(&[0xde, 0xad, 0xbe, 0xef]), 0xdeadbeef);
         assert_eq!(slice_to_u64_be(&[0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad, 0xca, 0xfe]), 0xdeadbeef1badcafe);
         assert_eq!(u32_to_array_be(0xdeadbeef), [0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(u64_to_array_be(0x1badcafedeadbeef), [0x1b, 0xad, 0xca, 0xfe, 0xde, 0xad, 0xbe, 0xef]);
 
         assert_eq!(slice_to_u16_le(&[0xad, 0xde]), 0xdead);
         assert_eq!(slice_to_u32_le(&[0xef, 0xbe, 0xad, 0xde]), 0xdeadbeef);

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,0 +1,351 @@
+// Bitcoin Numeric Library
+// Written in 2018 by
+//   Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! # Hex encoding and decoding
+//!
+
+use core::{fmt, str};
+
+/// Hex decoding error
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// non-hexadecimal character
+    InvalidChar(u8),
+    /// purported hex string had odd length
+    OddLengthString(usize),
+    /// tried to parse fixed-length hash from a string with the wrong type (expected, got)
+    InvalidLength(usize, usize),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::InvalidChar(ch) => write!(f, "invalid hex character {}", ch),
+            Error::OddLengthString(ell) => write!(f, "odd hex string length {}", ell),
+            Error::InvalidLength(ell, ell2) => write!(f, "bad hex string length {} (expected {})", ell2, ell),
+        }
+    }
+}
+
+/// Trait for objects that can be serialized as hex strings
+#[cfg(any(test, feature = "std"))]
+pub trait ToHex {
+    /// Hex representation of the object
+    fn to_hex(&self) -> String;
+}
+
+/// Trait for objects that can be deserialized from hex strings
+pub trait FromHex: Sized {
+    /// Produce an object from a byte iterator
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+        where I: Iterator<Item=Result<u8, Error>> +
+        ExactSizeIterator +
+        DoubleEndedIterator;
+
+    /// Produce an object from a hex string
+    fn from_hex(s: &str) -> Result<Self, Error> {
+        Self::from_byte_iter(HexIterator::new(s)?)
+    }
+}
+
+#[cfg(any(test, feature = "std"))]
+impl<T: fmt::LowerHex> ToHex for T {
+    /// Outputs the hash in hexadecimal form
+    fn to_hex(&self) -> String {
+        format!("{:x}", self)
+    }
+}
+
+/// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
+pub struct HexIterator<'a> {
+    /// The `Bytes` iterator whose next two bytes will be decoded to yield
+    /// the next byte.
+    iter: str::Bytes<'a>,
+}
+
+impl<'a> HexIterator<'a> {
+    /// Constructs a new `HexIterator` from a string slice. If the string is of
+    /// odd length it returns an error.
+    pub fn new(s: &'a str) -> Result<HexIterator<'a>, Error> {
+        if s.len() % 2 != 0 {
+            Err(Error::OddLengthString(s.len()))
+        } else {
+            Ok(HexIterator { iter: s.bytes() })
+        }
+    }
+}
+
+fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, Error> {
+    let hih = (hi as char)
+        .to_digit(16)
+        .ok_or(Error::InvalidChar(hi))?;
+    let loh = (lo as char)
+        .to_digit(16)
+        .ok_or(Error::InvalidChar(lo))?;
+
+    let ret = (hih << 4) + loh;
+    Ok(ret as u8)
+}
+
+impl<'a> Iterator for HexIterator<'a> {
+    type Item = Result<u8, Error>;
+
+    fn next(&mut self) -> Option<Result<u8, Error>> {
+        let hi = self.iter.next()?;
+        let lo = self.iter.next().unwrap();
+        Some(chars_to_hex(hi, lo))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.iter.size_hint();
+        (min / 2, max.map(|x| x /2))
+    }
+}
+
+impl<'a> DoubleEndedIterator for HexIterator<'a> {
+    fn next_back(&mut self) -> Option<Result<u8, Error>> {
+        let lo = self.iter.next_back()?;
+        let hi = self.iter.next_back().unwrap();
+        Some(chars_to_hex(hi, lo))
+    }
+}
+
+impl<'a> ExactSizeIterator for HexIterator<'a> {}
+
+/// Output hex into an object implementing `fmt::Write`, which is usually more
+/// efficient than going through a `String` using `ToHex`.
+pub fn format_hex(data: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
+    let prec = f.precision().unwrap_or(2 * data.len());
+    let width = f.width().unwrap_or(2 * data.len());
+    for _ in (2 * data.len())..width {
+        f.write_str("0")?;
+    }
+    for ch in data.iter().take(prec / 2) {
+        write!(f, "{:02x}", *ch)?;
+    }
+    if prec < 2 * data.len() && prec % 2 == 1 {
+        write!(f, "{:x}", data[prec / 2] / 16)?;
+    }
+    Ok(())
+}
+
+/// Output hex in reverse order; used for Sha256dHash whose standard hex encoding
+/// has the bytes reversed.
+pub fn format_hex_reverse(data: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
+    let prec = f.precision().unwrap_or(2 * data.len());
+    let width = f.width().unwrap_or(2 * data.len());
+    for _ in (2 * data.len())..width {
+        f.write_str("0")?;
+    }
+    for ch in data.iter().rev().take(prec / 2) {
+        write!(f, "{:02x}", *ch)?;
+    }
+    if prec < 2 * data.len() && prec % 2 == 1 {
+        write!(f, "{:x}", data[data.len() - 1 - prec / 2] / 16)?;
+    }
+    Ok(())
+}
+
+#[cfg(any(test, feature = "std"))]
+impl ToHex for [u8] {
+    fn to_hex(&self) -> String {
+        use core::fmt::Write;
+        let mut ret = String::with_capacity(2 * self.len());
+        for ch in self {
+            write!(ret, "{:02x}", ch).expect("writing to string");
+        }
+        ret
+    }
+}
+
+#[cfg(any(test, feature = "std"))]
+impl FromHex for Vec<u8> {
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+        where I: Iterator<Item=Result<u8, Error>> +
+        ExactSizeIterator +
+        DoubleEndedIterator,
+    {
+        iter.collect()
+    }
+}
+
+macro_rules! impl_fromhex_array {
+    ($len:expr) => {
+        impl FromHex for [u8; $len] {
+            fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+                where I: Iterator<Item=Result<u8, Error>> +
+                    ExactSizeIterator +
+                    DoubleEndedIterator,
+            {
+                if iter.len() == $len {
+                    let mut ret = [0; $len];
+                    for (n, byte) in iter.enumerate() {
+                        ret[n] = byte?;
+                    }
+                    Ok(ret)
+                } else {
+                    Err(Error::InvalidLength(2 * $len, 2 * iter.len()))
+                }
+            }
+        }
+    }
+}
+
+impl_fromhex_array!(2);
+impl_fromhex_array!(4);
+impl_fromhex_array!(6);
+impl_fromhex_array!(8);
+impl_fromhex_array!(10);
+impl_fromhex_array!(12);
+impl_fromhex_array!(14);
+impl_fromhex_array!(16);
+impl_fromhex_array!(20);
+impl_fromhex_array!(24);
+impl_fromhex_array!(28);
+impl_fromhex_array!(32);
+impl_fromhex_array!(33);
+impl_fromhex_array!(64);
+impl_fromhex_array!(65);
+impl_fromhex_array!(128);
+impl_fromhex_array!(256);
+impl_fromhex_array!(384);
+impl_fromhex_array!(512);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use core::fmt;
+
+    #[test]
+    fn hex_roundtrip() {
+        let expected = "0123456789abcdef";
+        let expected_up = "0123456789ABCDEF";
+
+        let parse: Vec<u8> = FromHex::from_hex(expected).expect("parse lowercase string");
+        assert_eq!(parse, vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        let ser = parse.to_hex();
+        assert_eq!(ser, expected);
+
+        let parse: Vec<u8> = FromHex::from_hex(expected_up).expect("parse uppercase string");
+        assert_eq!(parse, vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        let ser = parse.to_hex();
+        assert_eq!(ser, expected);
+
+        let parse: [u8; 8] = FromHex::from_hex(expected_up).expect("parse uppercase string");
+        assert_eq!(parse, [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        let ser = parse.to_hex();
+        assert_eq!(ser, expected);
+    }
+
+    #[test]
+    fn hex_truncate() {
+        struct HexBytes(Vec<u8>);
+        impl fmt::LowerHex for HexBytes {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                format_hex(&self.0, f)
+            }
+        }
+
+        let bytes = HexBytes(vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        assert_eq!(
+            format!("{:x}", bytes),
+            "0102030405060708090a"
+        );
+
+        for i in 0..20 {
+            assert_eq!(
+                format!("{:.prec$x}", bytes, prec = i),
+                &"0102030405060708090a"[0..i]
+            );
+        }
+
+        assert_eq!(
+            format!("{:25x}", bytes),
+            "000000102030405060708090a"
+        );
+        assert_eq!(
+            format!("{:26x}", bytes),
+            "0000000102030405060708090a"
+        );
+    }
+
+    #[test]
+    fn hex_truncate_rev() {
+        struct HexBytes(Vec<u8>);
+        impl fmt::LowerHex for HexBytes {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                format_hex_reverse(&self.0, f)
+            }
+        }
+
+        let bytes = HexBytes(vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        assert_eq!(
+            format!("{:x}", bytes),
+            "0a090807060504030201"
+        );
+
+        for i in 0..20 {
+            assert_eq!(
+                format!("{:.prec$x}", bytes, prec = i),
+                &"0a090807060504030201"[0..i]
+            );
+        }
+
+        assert_eq!(
+            format!("{:25x}", bytes),
+            "000000a090807060504030201"
+        );
+        assert_eq!(
+            format!("{:26x}", bytes),
+            "0000000a090807060504030201"
+        );
+    }
+
+    #[test]
+    fn hex_error() {
+        let oddlen = "0123456789abcdef0";
+        let badchar1 = "Z123456789abcdef";
+        let badchar2 = "012Y456789abcdeb";
+        let badchar3 = "«23456789abcdef";
+
+        assert_eq!(
+            Vec::<u8>::from_hex(oddlen),
+            Err(Error::OddLengthString(17))
+        );
+        assert_eq!(
+            <[u8; 4]>::from_hex(oddlen),
+            Err(Error::OddLengthString(17))
+        );
+        assert_eq!(
+            <[u8; 8]>::from_hex(oddlen),
+            Err(Error::OddLengthString(17))
+        );
+        assert_eq!(
+            Vec::<u8>::from_hex(badchar1),
+            Err(Error::InvalidChar(b'Z'))
+        );
+        assert_eq!(
+            Vec::<u8>::from_hex(badchar2),
+            Err(Error::InvalidChar(b'Y'))
+        );
+        assert_eq!(
+            Vec::<u8>::from_hex(badchar3),
+            Err(Error::InvalidChar(194))
+        );
+    }
+}
+

--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -1,0 +1,324 @@
+// Bitcoin Numeric Library
+// Written in 2014 by
+//     Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Internal Macros
+//!
+//! Macros meant to be used inside the Rust Bitcoin library
+
+/// Implements standard array methods for a given wrapper type
+macro_rules! impl_array_newtype {
+    ($thing:ident, $ty:ty, $len:expr) => {
+        impl $thing {
+            #[inline]
+            /// Converts the object to a raw pointer
+            pub fn as_ptr(&self) -> *const $ty {
+                let &$thing(ref dat) = self;
+                dat.as_ptr()
+            }
+
+            #[inline]
+            /// Converts the object to a mutable raw pointer
+            pub fn as_mut_ptr(&mut self) -> *mut $ty {
+                let &mut $thing(ref mut dat) = self;
+                dat.as_mut_ptr()
+            }
+
+            #[inline]
+            /// Returns the length of the object as an array
+            pub fn len(&self) -> usize { $len }
+
+            #[inline]
+            /// Returns whether the object, as an array, is empty. Always false.
+            pub fn is_empty(&self) -> bool { false }
+
+            #[inline]
+            /// Returns the underlying bytes.
+            pub fn as_bytes(&self) -> &[$ty; $len] { &self.0 }
+
+            #[inline]
+            /// Returns the underlying bytes.
+            pub fn to_bytes(&self) -> [$ty; $len] { self.0.clone() }
+
+            #[inline]
+            /// Returns the underlying bytes.
+            pub fn into_bytes(self) -> [$ty; $len] { self.0 }
+        }
+
+        impl<'a> ::std::convert::From<&'a [$ty]> for $thing {
+            fn from(data: &'a [$ty]) -> $thing {
+                assert_eq!(data.len(), $len);
+                let mut ret = [0; $len];
+                ret.copy_from_slice(&data[..]);
+                $thing(ret)
+            }
+        }
+
+        impl ::std::ops::Index<usize> for $thing {
+            type Output = $ty;
+
+            #[inline]
+            fn index(&self, index: usize) -> &$ty {
+                let &$thing(ref dat) = self;
+                &dat[index]
+            }
+        }
+
+        impl_index_newtype!($thing, $ty);
+
+        impl ::std::cmp::PartialEq for $thing {
+            #[inline]
+            fn eq(&self, other: &$thing) -> bool {
+                &self[..] == &other[..]
+            }
+        }
+
+        impl ::std::cmp::Eq for $thing {}
+
+        impl ::std::cmp::PartialOrd for $thing {
+            #[inline]
+            fn partial_cmp(&self, other: &$thing) -> Option<::std::cmp::Ordering> {
+                Some(self.cmp(&other))
+            }
+        }
+
+        impl ::std::cmp::Ord for $thing {
+            #[inline]
+            fn cmp(&self, other: &$thing) -> ::std::cmp::Ordering {
+                // manually implement comparison to get little-endian ordering
+                // (we need this for our numeric types; non-numeric ones shouldn't
+                // be ordered anyway except to put them in BTrees or whatever, and
+                // they don't care how we order as long as we're consistent).
+                for i in 0..$len {
+                    if self[$len - 1 - i] < other[$len - 1 - i] { return ::std::cmp::Ordering::Less; }
+                    if self[$len - 1 - i] > other[$len - 1 - i] { return ::std::cmp::Ordering::Greater; }
+                }
+                ::std::cmp::Ordering::Equal
+            }
+        }
+
+        #[cfg_attr(feature = "clippy", allow(expl_impl_clone_on_copy))] // we don't define the `struct`, we have to explicitly impl
+        impl ::std::clone::Clone for $thing {
+            #[inline]
+            fn clone(&self) -> $thing {
+                $thing::from(&self[..])
+            }
+        }
+
+        impl ::std::marker::Copy for $thing {}
+
+        impl ::std::hash::Hash for $thing {
+            #[inline]
+            fn hash<H>(&self, state: &mut H)
+                where H: ::std::hash::Hasher
+            {
+                (&self[..]).hash(state);
+            }
+
+            fn hash_slice<H>(data: &[$thing], state: &mut H)
+                where H: ::std::hash::Hasher
+            {
+                for d in data.iter() {
+                    (&d[..]).hash(state);
+                }
+            }
+        }
+    }
+}
+
+/// Implements debug formatting for a given wrapper type
+macro_rules! impl_array_newtype_show {
+    ($thing:ident) => {
+        impl ::std::fmt::Debug for $thing {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(f, concat!(stringify!($thing), "({:?})"), &self[..])
+            }
+        }
+    }
+}
+
+/// Implements standard indexing methods for a given wrapper type
+macro_rules! impl_index_newtype {
+    ($thing:ident, $ty:ty) => {
+        impl ::std::ops::Index<::std::ops::Range<usize>> for $thing {
+            type Output = [$ty];
+
+            #[inline]
+            fn index(&self, index: ::std::ops::Range<usize>) -> &[$ty] {
+                &self.0[index]
+            }
+        }
+
+        impl ::std::ops::Index<::std::ops::RangeTo<usize>> for $thing {
+            type Output = [$ty];
+
+            #[inline]
+            fn index(&self, index: ::std::ops::RangeTo<usize>) -> &[$ty] {
+                &self.0[index]
+            }
+        }
+
+        impl ::std::ops::Index<::std::ops::RangeFrom<usize>> for $thing {
+            type Output = [$ty];
+
+            #[inline]
+            fn index(&self, index: ::std::ops::RangeFrom<usize>) -> &[$ty] {
+                &self.0[index]
+            }
+        }
+
+        impl ::std::ops::Index<::std::ops::RangeFull> for $thing {
+            type Output = [$ty];
+
+            #[inline]
+            fn index(&self, _: ::std::ops::RangeFull) -> &[$ty] {
+                &self.0[..]
+            }
+        }
+
+    }
+}
+
+macro_rules! display_from_debug {
+    ($thing:ident) => {
+        impl ::std::fmt::Display for $thing {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Debug::fmt(self, f)
+            }
+        }
+    }
+}
+
+/// Implements several traits for byte-based newtypes.
+/// Implements:
+/// - std::fmt::LowerHex (implies hashes::hex::ToHex)
+/// - std::fmt::Display
+/// - std::str::FromStr
+/// - hashes::hex::FromHex
+macro_rules! impl_bytes_newtype {
+    ($t:ident, $len:expr) => (
+
+        impl ::std::fmt::LowerHex for $t {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                for &ch in self.0.iter() {
+                    write!(f, "{:02x}", ch)?;
+                }
+                Ok(())
+            }
+        }
+
+        impl ::std::fmt::Display for $t {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                fmt::LowerHex::fmt(self, f)
+            }
+        }
+
+        impl $crate::hex::FromHex for $t {
+            fn from_byte_iter<I>(iter: I) -> Result<Self, $crate::hex::Error>
+                where I: ::std::iter::Iterator<Item=Result<u8, $crate::hex::Error>> +
+                    ::std::iter::ExactSizeIterator +
+                    ::std::iter::DoubleEndedIterator,
+            {
+                if iter.len() == $len {
+                    let mut ret = [0; $len];
+                    for (n, byte) in iter.enumerate() {
+                        ret[n] = byte?;
+                    }
+                    Ok($t(ret))
+                } else {
+                    Err($crate::hex::Error::InvalidLength(2 * $len, 2 * iter.len()))
+                }
+            }
+        }
+
+        impl ::std::str::FromStr for $t {
+            type Err = $crate:::hex::Error;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                $crate::hex::FromHex::from_hex(s)
+            }
+        }
+
+        #[cfg(feature="serde")]
+        impl $crate::serde::Serialize for $t {
+            fn serialize<S: $crate::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+                if s.is_human_readable() {
+                    s.serialize_str(&$crate::hex::ToHex::to_hex(self))
+                } else {
+                    s.serialize_bytes(&self[..])
+                }
+            }
+        }
+
+        #[cfg(feature="serde")]
+        impl<'de> $crate::serde::Deserialize<'de> for $t {
+            fn deserialize<D: $crate::serde::Deserializer<'de>>(d: D) -> Result<$t, D::Error> {
+                if d.is_human_readable() {
+                    struct HexVisitor;
+
+                    impl<'de> $crate::serde::de::Visitor<'de> for HexVisitor {
+                        type Value = $t;
+
+                        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                            formatter.write_str("an ASCII hex string")
+                        }
+
+                        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            if let Ok(hex) = ::std::str::from_utf8(v) {
+                                $crate::hex::FromHex::from_hex(hex).map_err(E::custom)
+                            } else {
+                                return Err(E::invalid_value($crate::serde::de::Unexpected::Bytes(v), &self));
+                            }
+                        }
+
+                        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            $crate::hex::FromHex::from_hex(v).map_err(E::custom)
+                        }
+                    }
+
+                    d.deserialize_str(HexVisitor)
+                } else {
+                    struct BytesVisitor;
+
+                    impl<'de> $crate::serde::de::Visitor<'de> for BytesVisitor {
+                        type Value = $t;
+
+                        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                            formatter.write_str("a bytestring")
+                        }
+
+                        fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                        where
+                            E: $crate::serde::de::Error,
+                        {
+                            if v.len() != $len {
+                                Err(E::invalid_length(v.len(), &stringify!($len)))
+                            } else {
+                                let mut ret = [0; $len];
+                                ret.copy_from_slice(v);
+                                Ok($t(ret))
+                            }
+                        }
+                    }
+
+                    d.deserialize_bytes(BytesVisitor)
+                }
+            }
+        }
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 // Bitcoin Numeric Library
-// Written in 2018 by
+// Written in 2020 by
 //   Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
 //
 // To the extent possible under law, the author(s) have dedicated all
@@ -45,3 +45,6 @@
 
 pub(crate) mod endian;
 pub mod hex;
+#[macro_use]
+mod internal_macros;
+pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 
 #[cfg(any(test, feature="std"))] pub extern crate core;
 
-//#[cfg(any(test, feature = "std"))] mod std_impls;
+#[cfg(any(test, feature = "std"))] mod std_impls;
 
 pub(crate) mod endian;
+pub mod hex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Bitcoin Hashes Library
+// Bitcoin Numeric Library
 // Written in 2018 by
 //   Dr. Maxim Orlovsky <orlovsky@pandoracore.com>
 //
@@ -42,3 +42,5 @@
 #[cfg(any(test, feature="std"))] pub extern crate core;
 
 //#[cfg(any(test, feature = "std"))] mod std_impls;
+
+pub(crate) mod endian;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,4 +47,5 @@ pub(crate) mod endian;
 pub mod hex;
 #[macro_use]
 mod internal_macros;
+pub mod uint;
 pub mod util;

--- a/src/std_impls.rs
+++ b/src/std_impls.rs
@@ -1,0 +1,21 @@
+// Bitcoin Numeric Library
+// Written in 2018 by
+//   Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use std::error;
+use hex;
+
+impl error::Error for hex::Error {
+    fn cause(&self) -> Option<&error::Error> { None }
+    fn description(&self) -> &str { "`std::error::description` is deprecated" }
+}

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1,0 +1,559 @@
+// Bitcoin Numeric Library
+// Written in 2014 by
+//     Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Big unsigned integer types
+//!
+//! Implementation of a various large-but-fixed sized unsigned integer types.
+//! The functions here are designed to be fast.
+//!
+
+macro_rules! construct_uint {
+    ($name:ident, $n_words:expr) => (
+        /// Little-endian large integer type
+        #[repr(C)]
+        pub struct $name(pub [u64; $n_words]);
+        impl_array_newtype!($name, u64, $n_words);
+
+        impl $name {
+            /// Conversion to u32
+            #[inline]
+            pub fn low_u32(&self) -> u32 {
+                let &$name(ref arr) = self;
+                arr[0] as u32
+            }
+
+            /// Conversion to u64
+            #[inline]
+            pub fn low_u64(&self) -> u64 {
+                let &$name(ref arr) = self;
+                arr[0] as u64
+            }
+
+
+            /// Return the least number of bits needed to represent the number
+            #[inline]
+            pub fn bits(&self) -> usize {
+                let &$name(ref arr) = self;
+                for i in 1..$n_words {
+                    if arr[$n_words - i] > 0 { return (0x40 * ($n_words - i + 1)) - arr[$n_words - i].leading_zeros() as usize; }
+                }
+                0x40 - arr[0].leading_zeros() as usize
+            }
+
+            /// Multiplication by u32
+            pub fn mul_u32(self, other: u32) -> $name {
+                let $name(ref arr) = self;
+                let mut carry = [0u64; $n_words];
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    let not_last_word = i < $n_words - 1;
+                    let upper = other as u64 * (arr[i] >> 32);
+                    let lower = other as u64 * (arr[i] & 0xFFFFFFFF);
+                    if not_last_word {
+                        carry[i + 1] += upper >> 32;
+                    }
+                    let (sum, overflow) = lower.overflowing_add(upper << 32);
+                    ret[i] = sum;
+                    if overflow && not_last_word {
+                        carry[i + 1] += 1;
+                    }
+                }
+                $name(ret) + $name(carry)
+            }
+
+            /// Create an object from a given unsigned 64-bit integer
+            #[inline]
+            pub fn from_u64(init: u64) -> Option<$name> {
+                let mut ret = [0; $n_words];
+                ret[0] = init;
+                Some($name(ret))
+            }
+
+            /// Create an object from a given signed 64-bit integer
+            #[inline]
+            pub fn from_i64(init: i64) -> Option<$name> {
+                assert!(init >= 0);
+                $name::from_u64(init as u64)
+            }
+
+            /// Creates big integer value from a byte slice array using
+            /// big-endian encoding
+            pub fn from_be_bytes(bytes: [u8; $n_words * 8]) -> $name {
+                use super::endian::slice_to_u64_be;
+                let mut slice = [0u64; $n_words];
+                slice.iter_mut()
+                    .rev()
+                    .zip(bytes.chunks(8))
+                    .for_each(|(word, bytes)| *word = slice_to_u64_be(bytes));
+                $name(slice)
+            }
+
+            // divmod like operation, returns (quotient, remainder)
+            #[inline]
+            fn div_rem(self, other: Self) -> (Self, Self) {
+                let mut sub_copy = self;
+                let mut shift_copy = other;
+                let mut ret = [0u64; $n_words];
+
+                let my_bits = self.bits();
+                let your_bits = other.bits();
+
+                // Check for division by 0
+                assert!(your_bits != 0);
+
+                // Early return in case we are dividing by a larger number than us
+                if my_bits < your_bits {
+                    return ($name(ret), sub_copy);
+                }
+
+                // Bitwise long division
+                let mut shift = my_bits - your_bits;
+                shift_copy = shift_copy << shift;
+                loop {
+                    if sub_copy >= shift_copy {
+                        ret[shift / 64] |= 1 << (shift % 64);
+                        sub_copy = sub_copy - shift_copy;
+                    }
+                    shift_copy = shift_copy >> 1;
+                    if shift == 0 {
+                        break;
+                    }
+                    shift -= 1;
+                }
+
+                ($name(ret), sub_copy)
+            }
+        }
+
+        impl ::std::ops::Add<$name> for $name {
+            type Output = $name;
+
+            fn add(self, other: $name) -> $name {
+                let $name(ref me) = self;
+                let $name(ref you) = other;
+                let mut ret = [0u64; $n_words];
+                let mut carry = [0u64; $n_words];
+                let mut b_carry = false;
+                for i in 0..$n_words {
+                    ret[i] = me[i].wrapping_add(you[i]);
+                    if i < $n_words - 1 && ret[i] < me[i] {
+                        carry[i + 1] = 1;
+                        b_carry = true;
+                    }
+                }
+                if b_carry { $name(ret) + $name(carry) } else { $name(ret) }
+            }
+        }
+
+        impl ::std::ops::Sub<$name> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn sub(self, other: $name) -> $name {
+                self + !other + $crate::util::BitArray::one()
+            }
+        }
+
+        impl ::std::ops::Mul<$name> for $name {
+            type Output = $name;
+
+            fn mul(self, other: $name) -> $name {
+                use $crate::util::BitArray;
+                let mut me = $name::zero();
+                // TODO: be more efficient about this
+                for i in 0..(2 * $n_words) {
+                    let to_mul = (other >> (32 * i)).low_u32();
+                    me = me + (self.mul_u32(to_mul) << (32 * i));
+                }
+                me
+            }
+        }
+
+        impl ::std::ops::Div<$name> for $name {
+            type Output = $name;
+
+            fn div(self, other: $name) -> $name {
+                self.div_rem(other).0
+            }
+        }
+
+        impl ::std::ops::Rem<$name> for $name {
+            type Output = $name;
+
+            fn rem(self, other: $name) -> $name {
+                self.div_rem(other).1
+            }
+        }
+
+        impl $crate::util::BitArray for $name {
+            #[inline]
+            fn bit(&self, index: usize) -> bool {
+                let &$name(ref arr) = self;
+                arr[index / 64] & (1 << (index % 64)) != 0
+            }
+
+            #[inline]
+            fn bit_slice(&self, start: usize, end: usize) -> $name {
+                (*self >> start).mask(end - start)
+            }
+
+            #[inline]
+            fn mask(&self, n: usize) -> $name {
+                let &$name(ref arr) = self;
+                let mut ret = [0; $n_words];
+                for i in 0..$n_words {
+                    if n >= 0x40 * (i + 1) {
+                        ret[i] = arr[i];
+                    } else {
+                        ret[i] = arr[i] & ((1 << (n - 0x40 * i)) - 1);
+                        break;
+                    }
+                }
+                $name(ret)
+            }
+
+            #[inline]
+            fn trailing_zeros(&self) -> usize {
+                let &$name(ref arr) = self;
+                for i in 0..($n_words - 1) {
+                    if arr[i] > 0 { return (0x40 * i) + arr[i].trailing_zeros() as usize; }
+                }
+                (0x40 * ($n_words - 1)) + arr[$n_words - 1].trailing_zeros() as usize
+            }
+
+            fn zero() -> $name { $name([0; $n_words]) }
+            fn one() -> $name {
+                $name({ let mut ret = [0; $n_words]; ret[0] = 1; ret })
+            }
+        }
+
+        impl ::std::default::Default for $name {
+            fn default() -> $name {
+                $crate::util::BitArray::zero()
+            }
+        }
+
+        impl ::std::ops::BitAnd<$name> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn bitand(self, other: $name) -> $name {
+                let $name(ref arr1) = self;
+                let $name(ref arr2) = other;
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    ret[i] = arr1[i] & arr2[i];
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::BitXor<$name> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn bitxor(self, other: $name) -> $name {
+                let $name(ref arr1) = self;
+                let $name(ref arr2) = other;
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    ret[i] = arr1[i] ^ arr2[i];
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::BitOr<$name> for $name {
+            type Output = $name;
+
+            #[inline]
+            fn bitor(self, other: $name) -> $name {
+                let $name(ref arr1) = self;
+                let $name(ref arr2) = other;
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    ret[i] = arr1[i] | arr2[i];
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::Not for $name {
+            type Output = $name;
+
+            #[inline]
+            fn not(self) -> $name {
+                let $name(ref arr) = self;
+                let mut ret = [0u64; $n_words];
+                for i in 0..$n_words {
+                    ret[i] = !arr[i];
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::Shl<usize> for $name {
+            type Output = $name;
+
+            fn shl(self, shift: usize) -> $name {
+                let $name(ref original) = self;
+                let mut ret = [0u64; $n_words];
+                let word_shift = shift / 64;
+                let bit_shift = shift % 64;
+                for i in 0..$n_words {
+                    // Shift
+                    if bit_shift < 64 && i + word_shift < $n_words {
+                        ret[i + word_shift] += original[i] << bit_shift;
+                    }
+                    // Carry
+                    if bit_shift > 0 && i + word_shift + 1 < $n_words {
+                        ret[i + word_shift + 1] += original[i] >> (64 - bit_shift);
+                    }
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::ops::Shr<usize> for $name {
+            type Output = $name;
+
+            fn shr(self, shift: usize) -> $name {
+                let $name(ref original) = self;
+                let mut ret = [0u64; $n_words];
+                let word_shift = shift / 64;
+                let bit_shift = shift % 64;
+                for i in word_shift..$n_words {
+                    // Shift
+                    ret[i - word_shift] += original[i] >> bit_shift;
+                    // Carry
+                    if bit_shift > 0 && i < $n_words - 1 {
+                        ret[i - word_shift] += original[i + 1] << (64 - bit_shift);
+                    }
+                }
+                $name(ret)
+            }
+        }
+
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                let &$name(ref data) = self;
+                write!(f, "0x")?;
+                for ch in data.iter().rev() {
+                    write!(f, "{:016x}", ch)?;
+                }
+                Ok(())
+            }
+        }
+
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                <::std::fmt::Debug>::fmt(self, f)
+            }
+        }
+    );
+}
+
+construct_uint!(Uint256, 4);
+construct_uint!(Uint128, 2);
+
+impl Uint256 {
+    /// Increment by 1
+    #[inline]
+    pub fn increment(&mut self) {
+        let &mut Uint256(ref mut arr) = self;
+        arr[0] += 1;
+        if arr[0] == 0 {
+            arr[1] += 1;
+            if arr[1] == 0 {
+                arr[2] += 1;
+                if arr[2] == 0 {
+                    arr[3] += 1;
+                }
+            }
+        }
+    }
+
+    /// Decay to a uint128
+    #[inline]
+    pub fn low_128(&self) -> Uint128 {
+        let &Uint256(data) = self;
+        Uint128([data[0], data[1]])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use uint::{Uint256, Uint128};
+    use util::BitArray;
+
+    #[test]
+    pub fn uint256_bits_test() {
+        assert_eq!(Uint256::from_u64(255).unwrap().bits(), 8);
+        assert_eq!(Uint256::from_u64(256).unwrap().bits(), 9);
+        assert_eq!(Uint256::from_u64(300).unwrap().bits(), 9);
+        assert_eq!(Uint256::from_u64(60000).unwrap().bits(), 16);
+        assert_eq!(Uint256::from_u64(70000).unwrap().bits(), 17);
+
+        // Try to read the following lines out loud quickly
+        let mut shl = Uint256::from_u64(70000).unwrap();
+        shl = shl << 100;
+        assert_eq!(shl.bits(), 117);
+        shl = shl << 100;
+        assert_eq!(shl.bits(), 217);
+        shl = shl << 100;
+        assert_eq!(shl.bits(), 0);
+
+        // Bit set check
+        assert!(!Uint256::from_u64(10).unwrap().bit(0));
+        assert!(Uint256::from_u64(10).unwrap().bit(1));
+        assert!(!Uint256::from_u64(10).unwrap().bit(2));
+        assert!(Uint256::from_u64(10).unwrap().bit(3));
+        assert!(!Uint256::from_u64(10).unwrap().bit(4));
+    }
+
+    #[test]
+    pub fn uint256_display_test() {
+        assert_eq!(format!("{}", Uint256::from_u64(0xDEADBEEF).unwrap()),
+                   "0x00000000000000000000000000000000000000000000000000000000deadbeef");
+        assert_eq!(format!("{}", Uint256::from_u64(u64::max_value()).unwrap()),
+                   "0x000000000000000000000000000000000000000000000000ffffffffffffffff");
+
+        let max_val = Uint256([0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF,
+            0xFFFFFFFFFFFFFFFF]);
+        assert_eq!(format!("{}", max_val),
+                   "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    }
+
+    #[test]
+    pub fn uint256_comp_test() {
+        let small = Uint256([10u64, 0, 0, 0]);
+        let big = Uint256([0x8C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]);
+        let bigger = Uint256([0x9C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]);
+        let biggest = Uint256([0x5C8C3EE70C644118u64, 0x0209E7378231E632, 0, 1]);
+
+        assert!(small < big);
+        assert!(big < bigger);
+        assert!(bigger < biggest);
+        assert!(bigger <= biggest);
+        assert!(biggest <= biggest);
+        assert!(bigger >= big);
+        assert!(bigger >= small);
+        assert!(small <= small);
+    }
+
+    #[test]
+    pub fn uint_from_be_bytes() {
+        assert_eq!(Uint128::from_be_bytes([0x1b, 0xad, 0xca, 0xfe, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xaf, 0xba, 0xbe, 0x2b, 0xed, 0xfe, 0xed]),
+                   Uint128([0xdeafbabe2bedfeed, 0x1badcafedeadbeef]));
+
+        assert_eq!(Uint256::from_be_bytes([0x1b, 0xad, 0xca, 0xfe, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xaf, 0xba, 0xbe, 0x2b, 0xed, 0xfe, 0xed,
+            0xba, 0xad, 0xf0, 0x0d, 0xde, 0xfa, 0xce, 0xda, 0x11, 0xfe, 0xd2, 0xba, 0xd1, 0xc0, 0xff, 0xe0]),
+                   Uint256([0x11fed2bad1c0ffe0, 0xbaadf00ddefaceda, 0xdeafbabe2bedfeed, 0x1badcafedeadbeef]));
+    }
+
+    #[test]
+    pub fn uint256_arithmetic_test() {
+        let init = Uint256::from_u64(0xDEADBEEFDEADBEEF).unwrap();
+        let copy = init;
+
+        let add = init + copy;
+        assert_eq!(add, Uint256([0xBD5B7DDFBD5B7DDEu64, 1, 0, 0]));
+        // Bitshifts
+        let shl = add << 88;
+        assert_eq!(shl, Uint256([0u64, 0xDFBD5B7DDE000000, 0x1BD5B7D, 0]));
+        let shr = shl >> 40;
+        assert_eq!(shr, Uint256([0x7DDE000000000000u64, 0x0001BD5B7DDFBD5B, 0, 0]));
+        // Increment
+        let mut incr = shr;
+        incr.increment();
+        assert_eq!(incr, Uint256([0x7DDE000000000001u64, 0x0001BD5B7DDFBD5B, 0, 0]));
+        // Subtraction
+        let sub = incr - init;
+        assert_eq!(sub, Uint256([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0]));
+        // Multiplication
+        let mult = sub.mul_u32(300);
+        assert_eq!(mult, Uint256([0x8C8C3EE70C644118u64, 0x0209E7378231E632, 0, 0]));
+        // Division
+        assert_eq!(Uint256::from_u64(105).unwrap() /
+                       Uint256::from_u64(5).unwrap(),
+                   Uint256::from_u64(21).unwrap());
+        let div = mult / Uint256::from_u64(300).unwrap();
+        assert_eq!(div, Uint256([0x9F30411021524112u64, 0x0001BD5B7DDFBD5A, 0, 0]));
+
+        assert_eq!(Uint256::from_u64(105).unwrap() % Uint256::from_u64(5).unwrap(),
+                   Uint256::from_u64(0).unwrap());
+        assert_eq!(Uint256::from_u64(35498456).unwrap() % Uint256::from_u64(3435).unwrap(),
+                   Uint256::from_u64(1166).unwrap());
+        let rem_src = mult * Uint256::from_u64(39842).unwrap() + Uint256::from_u64(9054).unwrap();
+        assert_eq!(rem_src % Uint256::from_u64(39842).unwrap(),
+                   Uint256::from_u64(9054).unwrap());
+        // TODO: bit inversion
+    }
+
+    #[test]
+    pub fn mul_u32_test() {
+        let u64_val = Uint256::from_u64(0xDEADBEEFDEADBEEF).unwrap();
+
+        let u96_res = u64_val.mul_u32(0xFFFFFFFF);
+        let u128_res = u96_res.mul_u32(0xFFFFFFFF);
+        let u160_res = u128_res.mul_u32(0xFFFFFFFF);
+        let u192_res = u160_res.mul_u32(0xFFFFFFFF);
+        let u224_res = u192_res.mul_u32(0xFFFFFFFF);
+        let u256_res = u224_res.mul_u32(0xFFFFFFFF);
+
+        assert_eq!(u96_res, Uint256([0xffffffff21524111u64, 0xDEADBEEE, 0, 0]));
+        assert_eq!(u128_res, Uint256([0x21524111DEADBEEFu64, 0xDEADBEEE21524110, 0, 0]));
+        assert_eq!(u160_res, Uint256([0xBD5B7DDD21524111u64, 0x42A4822200000001, 0xDEADBEED, 0]));
+        assert_eq!(u192_res, Uint256([0x63F6C333DEADBEEFu64, 0xBD5B7DDFBD5B7DDB, 0xDEADBEEC63F6C334, 0]));
+        assert_eq!(u224_res, Uint256([0x7AB6FBBB21524111u64, 0xFFFFFFFBA69B4558, 0x854904485964BAAA, 0xDEADBEEB]));
+        assert_eq!(u256_res, Uint256([0xA69B4555DEADBEEFu64, 0xA69B455CD41BB662, 0xD41BB662A69B4550, 0xDEADBEEAA69B455C]));
+    }
+
+    #[test]
+    pub fn multiplication_test() {
+        let u64_val = Uint256::from_u64(0xDEADBEEFDEADBEEF).unwrap();
+
+        let u128_res = u64_val * u64_val;
+
+        assert_eq!(u128_res, Uint256([0x048D1354216DA321u64, 0xC1B1CD13A4D13D46, 0, 0]));
+
+        let u256_res = u128_res * u128_res;
+
+        assert_eq!(u256_res, Uint256([0xF4E166AAD40D0A41u64, 0xF5CF7F3618C2C886u64,
+            0x4AFCFF6F0375C608u64, 0x928D92B4D7F5DF33u64]));
+    }
+
+    #[test]
+    pub fn uint256_bitslice_test() {
+        let init = Uint256::from_u64(0xDEADBEEFDEADBEEF).unwrap();
+        let add = init + (init << 64);
+        assert_eq!(add.bit_slice(64, 128), init);
+        assert_eq!(add.mask(64), init);
+    }
+
+    #[test]
+    pub fn uint256_extreme_bitshift_test() {
+        // Shifting a u64 by 64 bits gives an undefined value, so make sure that
+        // we're doing the Right Thing here
+        let init = Uint256::from_u64(0xDEADBEEFDEADBEEF).unwrap();
+
+        assert_eq!(init << 64, Uint256([0, 0xDEADBEEFDEADBEEF, 0, 0]));
+        let add = (init << 64) + init;
+        assert_eq!(add, Uint256([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0]));
+        assert_eq!(add >> 0, Uint256([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0]));
+        assert_eq!(add << 0, Uint256([0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0, 0]));
+        assert_eq!(add >> 64, Uint256([0xDEADBEEFDEADBEEF, 0, 0, 0]));
+        assert_eq!(add << 64, Uint256([0, 0xDEADBEEFDEADBEEF, 0xDEADBEEFDEADBEEF, 0]));
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,38 @@
+// Bitcoin Numeric Library
+// Written in 2014 by
+//     Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Utility functions
+//!
+//! Functions needed by all parts of the Bitcoin library
+
+/// A trait which allows numbers to act as fixed-size bit arrays
+pub trait BitArray {
+    /// Is bit set?
+    fn bit(&self, idx: usize) -> bool;
+
+    /// Returns an array which is just the bits from start to end
+    fn bit_slice(&self, start: usize, end: usize) -> Self;
+
+    /// Bitwise and with `n` ones
+    fn mask(&self, n: usize) -> Self;
+
+    /// Trailing zeros
+    fn trailing_zeros(&self) -> usize;
+
+    /// Create all-zeros value
+    fn zero() -> Self;
+
+    /// Create value representing one
+    fn one() -> Self;
+}


### PR DESCRIPTION
CI fails due to the fact that code transferred from rust-bitcoin uses `::std` in macros (instead of `::core`), making `--no-default-features` to error. This is left as it is for all to give ability to check byte-to-byte correspondence of the code to its original. In the next commits from #2 this is fixed and the code builds.